### PR TITLE
Ensure word boundary after `true`

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -409,7 +409,7 @@
                 {
                     "comment": "booleans",
                     "name": "constant.language.bool.rust",
-                    "match": "\\btrue|false\\b"
+                    "match": "\\b(true|false)\\b"
                 }
             ]
         },

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -237,7 +237,7 @@ repository:
       -
         comment: booleans
         name: constant.language.bool.rust
-        match: \btrue|false\b
+        match: \b(true|false)\b
   escapes:
     comment: 'escapes: ASCII, byte, Unicode, quote, regex'
     name: constant.character.escape.rust


### PR DESCRIPTION
Adding round brackets ensures word boundaries on both sides of booleans.

Fixes #7.