### PR TITLE
allow lifetimes in attributes

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -149,6 +149,9 @@
                     "include": "#keywords"
                 },
                 {
+                    "include": "#lifetimes"
+                },
+                {
                     "include": "#punctuation"
                 },
                 {

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -90,6 +90,7 @@ patterns:
       - include: '#block-comments'
       - include: '#comments'
       - include: '#keywords'
+      - include: '#lifetimes'
       - include: '#punctuation'
       - include: '#strings'
       - include: '#gtypes'


### PR DESCRIPTION
Fixes #11.

Precedence is used to catch lifetimes before chars. By allowing strings inside attributes, and making chars a subset of strings in the grammar, we inadvertently allowed chars in attributes without allowing lifetimes. The result is that lifetimes are treated as unclosed chars when they appear in an attribute. The easy fix is to allow lifetimes inside attributes.