### PR TITLE
Fix an issue that `\xN8` and `\xN9` in strings are differently colored

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -419,7 +419,7 @@
         "escapes": {
             "comment": "escapes: ASCII, byte, Unicode, quote, regex",
             "name": "constant.character.escape.rust",
-            "match": "(\\\\)(?:(?:(x[0-7][0-9a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+            "match": "(\\\\)(?:(?:(x[0-7][\\da-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
             "captures": {
                 "1": {
                     "name": "constant.character.escape.backslash.rust"

--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -419,7 +419,7 @@
         "escapes": {
             "comment": "escapes: ASCII, byte, Unicode, quote, regex",
             "name": "constant.character.escape.rust",
-            "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+            "match": "(\\\\)(?:(?:(x[0-7][0-9a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
             "captures": {
                 "1": {
                     "name": "constant.character.escape.backslash.rust"

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -242,7 +242,7 @@ repository:
   escapes:
     comment: 'escapes: ASCII, byte, Unicode, quote, regex'
     name: constant.character.escape.rust
-    match: (\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\{)[\da-fA-F]{4,6}(\}))|.))
+    match: (\\)(?:(?:(x[0-7][\da-fA-F])|(u(\{)[\da-fA-F]{4,6}(\}))|.))
     captures:
       1:
         name: constant.character.escape.backslash.rust


### PR DESCRIPTION
Hi, this PR provides a fix for an issue that `\xN8` and `\xN9` (N = 0-7) in strings are colored differently from other ASCII escape characters such as `\xN0` and `\xNf`.  You can see the issue in a screenshot attached to #33.

I would appreciate it if you could incorporate the modifications when you have time.
Many thanks!

Closes #33.