### PR TITLE
Fix namespace highlighting with uppercase

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -886,7 +886,7 @@
             "patterns": [
                 {
                     "comment": "namespace (non-type, non-function path segment)",
-                    "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+                    "match": "(?<![A-Za-z0-9_])([A-Za-z0-9_]+)((?<!super|self)::)",
                     "captures": {
                         "1": {
                             "name": "entity.name.namespace.rust"

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -533,7 +533,7 @@ repository:
     patterns:
       -
         comment: namespace (non-type, non-function path segment)
-        match: (?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)
+        match: (?<![A-Za-z0-9_])([A-Za-z0-9_]+)((?<!super|self)::)
         captures:
           1:
             name: entity.name.namespace.rust


### PR DESCRIPTION
In general, lowercase is used for namespace and it is recommended, but uppercase can also be used for namespace, such as [windows-rs](https://github.com/microsoft/windows-rs).