### PR TITLE
Mark documentation comment blocks as Markdown.

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -298,7 +298,14 @@
                 {
                     "comment": "documentation comments",
                     "name": "comment.line.documentation.rust",
-                    "match": "^\\s*///.*"
+                    "begin": "^\\s*//(/|!)",
+                    "while": "^\\s*//(/|!)",
+                    "contentName": "meta.embedded.block.markdown",
+                    "patterns": [
+                        {
+                            "include": "text.html.markdown"
+                        }
+                    ]
                 },
                 {
                     "comment": "line comments",
@@ -317,11 +324,15 @@
                 {
                     "comment": "block documentation comments",
                     "name": "comment.block.documentation.rust",
-                    "begin": "/\\*\\*",
-                    "end": "\\*/",
+					"begin": "/\\*(\\*|!)",
+					"end": "\\s*\\*/",
+                    "contentName": "meta.embedded.block.markdown",
                     "patterns": [
                         {
                             "include": "#block-comments"
+                        },
+                        {
+                            "include": "text.html.markdown"
                         }
                     ]
                 },

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -160,7 +160,11 @@ repository:
       -
         comment: documentation comments
         name: comment.line.documentation.rust
-        match: ^\s*///.*
+        begin: ^\\s*//(/|!)
+        while: ^\\s*//(/|!)
+        contentName: meta.embedded.block.markdown
+        patterns:
+          - include: text.html.markdown
       -
         comment: line comments
         name: comment.line.double-slash.rust
@@ -174,10 +178,12 @@ repository:
       -
         comment: block documentation comments
         name: comment.block.documentation.rust
-        begin: /\*\*
-        end: \*/
+        begin: /\\*(\\*|!)
+        end: \\s*\\*/
+        contentName: meta.embedded.block.markdown
         patterns:
           - include: '#block-comments'
+          - include: text.html.markdown
       -
         comment: block comments
         name: comment.block.rust


### PR DESCRIPTION
This adds support for marking the content inside of a doc comment as markdown. Additionally the following identifiers are marked as documentation blocks as well:
- `//!`
- `/*!`

These were previously identified as the double slash / non-doc variant. These are defined in the Rust spec: https://doc.rust-lang.org/reference/comments.html

Examples of how this looks in VS Code:

![image](https://user-images.githubusercontent.com/1593486/209414683-e6537484-353a-419b-9474-966ebd72f532.png)

![image](https://user-images.githubusercontent.com/1593486/209414691-88796735-4d28-443e-adda-f35d9cf01ce1.png)

This comes from my original issue https://github.com/microsoft/vscode/issues/169676 and I hope to sync this to the PR for VS Code as well: https://github.com/microsoft/vscode/pull/169956. #20 also suggested this feature.

Let me know what you think. 😃
