### PR TITLE
Add `gen` keyword

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -697,7 +697,7 @@
                 {
                     "comment": "other keywords",
                     "name": "keyword.other.rust",
-                    "match": "\\b(as|async|become|box|dyn|move|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
+                    "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
                 },
                 {
                     "comment": "fn",

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -393,7 +393,7 @@ repository:
       -
         comment: other keywords
         name: keyword.other.rust
-        match: \b(as|async|become|box|dyn|move|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\b
+        match: \b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\b
       -
         comment: fn
         name: keyword.other.fn.rust


### PR DESCRIPTION
As this is an edition 2024 keyword I don't know whether we want to do this. Because this will then also incorrectly highlight e.g. variable identifiers named `gen` in edition 2021