### PR TITLE
fix: fix tokenization of line comments

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -253,12 +253,22 @@
                 {
                     "comment": "documentation comments",
                     "name": "comment.line.documentation.rust",
-                    "match": "^\\s*///.*"
+                    "match": "(///).*$",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.rust"
+                        }
+                    }
                 },
                 {
                     "comment": "line comments",
                     "name": "comment.line.double-slash.rust",
-                    "match": "\\s*//.*"
+                    "match": "(//).*$",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.rust"
+                        }
+                    }
                 }
             ]
         },

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -137,11 +137,17 @@ repository:
       -
         comment: documentation comments
         name: comment.line.documentation.rust
-        match: ^\s*///.*
+        match: (///).*$
+        captures:
+          1:
+            name: punctuation.definition.comment.rust
       -
         comment: line comments
         name: comment.line.double-slash.rust
-        match: \s*//.*
+        match: "(//).*$"
+        captures:
+          1:
+            name: punctuation.definition.comment.rust
   block-comments:
     patterns:
       -

--- a/test/test_line_comment.rs
+++ b/test/test_line_comment.rs
@@ -1,0 +1,19 @@
+// SYNTAX TEST "source.rust" "Textmate grammar scope tests for line comment"
+
+// This file is a placeholder stub that will gradually be expanded to unit test all scopes.
+// Instructions for writing Textmate grammar tests can be found at:
+// https://github.com/PanAeon/vscode-tmgrammar-test/blob/master/README.md
+
+    // some comment content
+//  ^^                          punctuation.definition.comment.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^     comment.line.double-slash.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^     source.rust
+// <----                        source.rust
+
+    /// some comment content
+//  ^^^                         punctuation.definition.comment.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^^    comment.line.documentation.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^^    source.rust
+// <----                        source.rust
+
+


### PR DESCRIPTION
white-space before line comments should not be tokenized as comment

Before:

```rust
    // some comment content
^^^^^^^^^^^^^^^^^^^^^^^^^^^     comment.line.double-slash.rust
^^^^^^^^^^^^^^^^^^^^^^^^^^^     source.rust

    /// some comment content
^^^^^^^^^^^^^^^^^^^^^^^^^^^^    comment.line.documentation.rust
^^^^^^^^^^^^^^^^^^^^^^^^^^^^    source.rust
```

After:

```rust
    // some comment content
    ^^                          punctuation.definition.comment.rust
    ^^^^^^^^^^^^^^^^^^^^^^^     comment.line.double-slash.rust
^^^^^^^^^^^^^^^^^^^^^^^^^^^     source.rust

    /// some comment content
    ^^^                         punctuation.definition.comment.rust
    ^^^^^^^^^^^^^^^^^^^^^^^^    comment.line.documentation.rust
^^^^^^^^^^^^^^^^^^^^^^^^^^^^    source.rust
```