### PR TITLE
Add left arrow <- token

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -818,7 +818,7 @@
                 {
                     "comment": "dashrocket, skinny arrow",
                     "name": "keyword.operator.arrow.skinny.rust",
-                    "match": "->"
+                    "match": "->|<-"
                 },
                 {
                     "comment": "hashrocket, fat arrow",

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -483,7 +483,7 @@ repository:
       -
         comment: dashrocket, skinny arrow
         name: keyword.operator.arrow.skinny.rust
-        match: ->
+        match: ->|<-
       -
         comment: hashrocket, fat arrow
         name: keyword.operator.arrow.fat.rust


### PR DESCRIPTION
> The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token

https://doc.rust-lang.org/reference/tokens.html#punctuation

---

I noticed while using macros that call for the `<-` token that it gets highlighted as `<` and `-` separately. rustc parses it as a single token, as demonstrated [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+valid%28%29+%7B%0A++++dbg%21%281+%3C+-2%29%3B%0A%7D%0A%0Afn+invalid%28%29+%7B%0A++++dbg%21%281+%3C-2%29%3B%0A%7D%0A).

