### PR TITLE
fix scope for semicolon after fn declaration

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -480,10 +480,13 @@
                             "name": "punctuation.brackets.angle.rust"
                         }
                     },
-                    "end": "\\{|;",
+                    "end": "(\\{)|(;)",
                     "endCaptures": {
-                        "0": {
+                        "1": {
                             "name": "punctuation.brackets.curly.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.semi.rust"
                         }
                     },
                     "patterns": [

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -282,10 +282,12 @@ repository:
             name: punctuation.brackets.round.rust
           5:
             name: punctuation.brackets.angle.rust
-        end: \{|;
+        end: (\{)|(;)
         endCaptures:
-          0:
+          1:
             name: punctuation.brackets.curly.rust
+          2:
+            name: punctuation.semi.rust
         patterns:
           - include: '#block-comments'
           - include: '#comments'


### PR DESCRIPTION
Previously, the semicolon at the end of a fn declaration without a body (e.g. in a trait) had the `punctuation.brackets.curly.rust` scope. This change makes it a `punctuation.semi.rust` instead.