### PR TITLE
update fragment specifiers/allow spaces in metavariable declarations

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -50,7 +50,7 @@
         {
             "comment": "macro type metavariables",
             "name": "meta.macro.metavariable.type.rust",
-            "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+            "match": "(\\$)((crate)|([A-Z]\\w*))(\\s*(:)\\s*(block|expr(?:_2021)?|ident|item|lifetime|literal|meta|pat(?:_param)?|path|stmt|tt|ty|vis)\\b)?",
             "captures": {
                 "1": {
                     "name": "keyword.operator.macro.dollar.rust"
@@ -77,7 +77,7 @@
         {
             "comment": "macro metavariables",
             "name": "meta.macro.metavariable.rust",
-            "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?",
+            "match": "(\\$)([a-z]\\w*)(\\s*(:)\\s*(block|expr(?:_2021)?|ident|item|lifetime|literal|meta|pat(?:_param)?|path|stmt|tt|ty|vis)\\b)?",
             "captures": {
                 "1": {
                     "name": "keyword.operator.macro.dollar.rust"

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -29,7 +29,7 @@ patterns:
   -
     comment: macro type metavariables
     name: meta.macro.metavariable.type.rust
-    match: (\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?
+    match: (\$)((crate)|([A-Z]\w*))(\s*(:)\s*(block|expr(?:_2021)?|ident|item|lifetime|literal|meta|pat(?:_param)?|path|stmt|tt|ty|vis)\b)?
     captures:
       1:
         name: keyword.operator.macro.dollar.rust
@@ -46,7 +46,7 @@ patterns:
   -
     comment: macro metavariables
     name: meta.macro.metavariable.rust
-    match: (\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|path?|stmt|tt|ty|vis))?
+    match: (\$)([a-z]\w*)(\s*(:)\s*(block|expr(?:_2021)?|ident|item|lifetime|literal|meta|pat(?:_param)?|path|stmt|tt|ty|vis)\b)?
     captures:
       1:
         name: keyword.operator.macro.dollar.rust

--- a/test/test.rs
+++ b/test/test.rs
@@ -46,3 +46,44 @@ let x6 = 1.123E-12;
 //            ^ keyword.operator.exponent.rust
 //             ^ keyword.operator.exponent.sign.rust
 //              ^^ constant.numeric.decimal.exponent.mantissa.rust
+
+// macro metavarables
+macro_rules! metavariable_test {
+    ($var:tt $Type:ty $var : tt $Type :ty) => {};
+//   ^^^^^^^          ^^^^^^^^^             meta.macro.metavariable.rust
+//           ^^^^^^^^           ^^^^^^^^^   meta.macro.metavariable.type.rust
+//   ^       ^        ^         ^           keyword.operator.macro.dollar.rust
+//    ^^^              ^^^                  variable.other.metavariable.name.rust
+//            ^^^^               ^^^^       entity.name.type.metavariable.rust
+//       ^        ^        ^          ^     keyword.operator.key-value.rust
+//        ^^       ^^        ^^        ^^   variable.other.metavariable.specifier.rust
+    ($var:pat_param $Var:pat_param) => {};
+//   ^^^^^^^^^^^^^^                         meta.macro.metavariable.rust
+//                  ^^^^^^^^^^^^^^          meta.macro.metavariable.type.rust
+//   ^              ^                       keyword.operator.macro.dollar.rust
+//    ^^^                                   variable.other.metavariable.name.rust
+//                   ^^^                    entity.name.type.metavariable.rust
+//       ^              ^                   keyword.operator.key-value.rust
+//        ^^^^^^^^^      ^^^^^^^^^          variable.other.metavariable.specifier.rust
+    ($var: expr_2021 $Var: expr_2021) => {};
+//   ^^^^^^^^^^^^^^^                        meta.macro.metavariable.rust
+//                   ^^^^^^^^^^^^^^^        meta.macro.metavariable.type.rust
+//   ^               ^                      keyword.operator.macro.dollar.rust
+//    ^^^                                   variable.other.metavariable.name.rust
+//                    ^^^                   entity.name.type.metavariable.rust
+//       ^               ^                  keyword.operator.key-value.rust
+//         ^^^^^^^^^       ^^^^^^^^^        variable.other.metavariable.specifier.rust
+    () => { $var $Type $crate };
+//          ^^^^                            meta.macro.metavariable.rust
+//               ^^^^^ ^^^^^^               meta.macro.metavariable.type.rust
+//              ^     ^      ^              - meta.macro.metavariable.rust meta.macro.metavariable.type.rust
+//          ^    ^     ^                    keyword.operator.macro.dollar.rust
+//           ^^^                            variable.other.metavariable.name.rust
+//                ^^^^                      entity.name.type.metavariable.rust
+//                      ^^^^^               keyword.other.crate.rust
+    () => { $var: not_a_specifier };
+//          ^^^^                            meta.macro.metavariable.rust
+//          ^                               keyword.operator.macro.dollar.rust
+//           ^^^                            variable.other.metavariable.name.rust
+//              ^^^^^^^^^^^^^^^^^           - meta.macro.metavariable.rust
+}


### PR DESCRIPTION
I came across a Rust project with macros that put a space after the colon in a macro metavariable declaration (e.g. `$var: literal`) and noticed the fragment specifier didn't get the `variable.other.metavariable.specifier.rust` scope. Additionally, `pat_param` isn't in the list so `pat` would get the scope but not `_param`. Plus Rust 2024 edition is adding an `expr_2021` fragment specifier for backward compatibility with macros written for 2021 edition.

---
 
- Add `pat_param` specifier from 2021 edition
- Add `expr_2021` specifier from 2024 edition: https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html
  - This specifier is currently unstable but the name seems to be confirmed: https://github.com/rust-lang/rust/issues/123742#issuecomment-2315764431
- Require a word boundary (`\b`) at the end of the specifier
- Replace `[A-Za-z0-9_]` with `\w`
- Allow spaces before and after the `:` in metavariable declarations
- Add tests for the new specifiers and spacing