### PR TITLE
Explicitly match bracket pairs inside attributes

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -403,25 +403,65 @@
                 }
             }
         },
-        "attributes": {
-            "comment": "attributes",
-            "name": "meta.attribute.rust",
-            "begin": "(#)(\\!?)(\\[)",
-            "beginCaptures": {
-                "1": {
-                    "name": "punctuation.definition.attribute.rust"
-                },
-                "3": {
-                    "name": "punctuation.brackets.attribute.rust"
-                }
-            },
-            "end": "\\]",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.brackets.attribute.rust"
-                }
-            },
+        "attribute-inner": {
             "patterns": [
+                {
+                    "begin": "\\(",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.round.rust"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.round.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#attribute-inner"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\[",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.square.rust"
+                        }
+                    },
+                    "end": "\\]",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.square.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#attribute-inner"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\{",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.curly.rust"
+                        }
+                    },
+                    "end": "\\}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.curly.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#attribute-inner"
+                        }
+                    ]
+                },
                 {
                     "include": "#block-comments"
                 },
@@ -445,6 +485,30 @@
                 },
                 {
                     "include": "#types"
+                }
+            ]
+        },
+        "attributes": {
+            "comment": "attributes",
+            "name": "meta.attribute.rust",
+            "begin": "(#)(\\!?)(\\[)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.attribute.rust"
+                },
+                "3": {
+                    "name": "punctuation.brackets.attribute.rust"
+                }
+            },
+            "end": "\\]",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.brackets.attribute.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#attribute-inner"
                 }
             ]
         },

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -237,6 +237,46 @@ repository:
         name: constant.character.escape.unicode.punctuation.rust
       5:
         name: constant.character.escape.unicode.punctuation.rust
+  attribute-inner:
+    patterns:
+      - begin: '\('
+        beginCaptures:
+          0:
+            name: punctuation.brackets.round.rust
+        end: '\)'
+        endCaptures:
+          0:
+            name: punctuation.brackets.round.rust
+        patterns:
+          - include: '#attribute-inner'
+      - begin: '\['
+        beginCaptures:
+          0:
+            name: punctuation.brackets.square.rust
+        end: '\]'
+        endCaptures:
+          0:
+            name: punctuation.brackets.square.rust
+        patterns:
+          - include: '#attribute-inner'
+      - begin: '\{'
+        beginCaptures:
+          0:
+            name: punctuation.brackets.curly.rust
+        end: '\}'
+        endCaptures:
+          0:
+            name: punctuation.brackets.curly.rust
+        patterns:
+          - include: '#attribute-inner'
+      - include: '#block-comments'
+      - include: '#comments'
+      - include: '#keywords'
+      - include: '#lifetimes'
+      - include: '#punctuation'
+      - include: '#strings'
+      - include: '#gtypes'
+      - include: '#types'
   attributes:
     comment: attributes
     name: meta.attribute.rust
@@ -251,14 +291,7 @@ repository:
       0:
         name: punctuation.brackets.attribute.rust
     patterns:
-      - include: '#block-comments'
-      - include: '#comments'
-      - include: '#keywords'
-      - include: '#lifetimes'
-      - include: '#punctuation'
-      - include: '#strings'
-      - include: '#gtypes'
-      - include: '#types'
+      - include: '#attribute-inner'
   functions:
     patterns:
       -


### PR DESCRIPTION
Fixes #52. Adds explicit capturing of bracket pairs within attributes to ensure the `meta.attribute` scope always extends through the outermost square bracket.

![image](https://github.com/user-attachments/assets/628b3d59-72fb-4e75-8e71-4c5521e95855)
