### PR TITLE
improved handling of weak keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     },
     "scripts": {
         "start": "npx gulp watch-yaml",
+        "build": "npx gulp yaml",
+        "pretest": "npm run build",
         "test": "npm run test-TM-scope",
         "test-TM-scope": "npx vscode-tmgrammar-test \"./test/**/test*.rs\" --compact --grammar ./syntaxes/rust.tmLanguage.json"
     },

--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -312,12 +312,15 @@
                 },
                 {
                     "comment": "constant declarations",
-                    "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                    "match": "\\b(?:(safe|unsafe)\\s+)?(const|static)\\s+([A-Z][A-Za-z0-9_]*)\\b",
                     "captures": {
                         "1": {
-                            "name": "storage.type.rust"
+                            "name": "keyword.other.safety.rust"
                         },
                         "2": {
+                            "name": "storage.type.rust"
+                        },
+                        "3": {
                             "name": "constant.other.caps.rust"
                         }
                     }
@@ -465,18 +468,21 @@
                 {
                     "comment": "function definition",
                     "name": "meta.function.definition.rust",
-                    "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
+                    "begin": "\\b(?:(safe|unsafe)\\s+)?(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
                     "beginCaptures": {
                         "1": {
-                            "name": "keyword.other.fn.rust"
+                            "name": "keyword.other.safety.rust"
                         },
                         "2": {
+                            "name": "keyword.other.fn.rust"
+                        },
+                        "3": {
                             "name": "entity.name.function.rust"
                         },
-                        "4": {
+                        "5": {
                             "name": "punctuation.brackets.round.rust"
                         },
-                        "5": {
+                        "6": {
                             "name": "punctuation.brackets.angle.rust"
                         }
                     },
@@ -710,7 +716,7 @@
                 {
                     "comment": "other keywords",
                     "name": "keyword.other.rust",
-                    "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
+                    "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|unsafe|unsized|use|virtual|where)\\b"
                 },
                 {
                     "comment": "fn",
@@ -733,9 +739,20 @@
                     "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
                 },
                 {
-                    "comment": "logical AND, borrow references",
+                    "comment": "bitwise AND, borrow references",
                     "name": "keyword.operator.borrow.and.rust",
-                    "match": "&(?![&=])"
+                    "match": "&(?![&=])(?:\\s*(raw)\\b)?(?:\\s*(?:(const)|(mut))\\b)?",
+                    "captures": {
+                        "1": {
+                            "name": "storage.modifier.raw.rust"
+                        },
+                        "2": {
+                            "name": "storage.modifier.const.rust"
+                        },
+                        "3": {
+                            "name": "storage.modifier.mut.rust"
+                        }
+                    }
                 },
                 {
                     "comment": "assignment operators",
@@ -1022,6 +1039,18 @@
                         },
                         "2": {
                             "name": "entity.name.type.declaration.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "union declarations",
+                    "match": "\\b(union)\\s+(_?[A-Z][A-Za-z0-9_]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.declaration.union.rust storage.type.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.union.rust"
                         }
                     }
                 },

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -176,11 +176,13 @@ repository:
         match: \b[A-Z]{2}[A-Z0-9_]*\b
       -
         comment: constant declarations
-        match: \b(const)\s+([A-Z][A-Za-z0-9_]*)\b
+        match: \b(?:(safe|unsafe)\s+)?(const|static)\s+([A-Z][A-Za-z0-9_]*)\b
         captures:
           1:
-            name: storage.type.rust
+            name: keyword.other.safety.rust
           2:
+            name: storage.type.rust
+          3:
             name: constant.other.caps.rust
       -
         comment: decimal integers and floats
@@ -272,15 +274,18 @@ repository:
       -
         comment: function definition
         name: meta.function.definition.rust
-        begin: \b(fn)\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\()|(<))
+
+        begin: \b(?:(safe|unsafe)\s+)?(fn)\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\()|(<))
         beginCaptures:
           1:
-            name: keyword.other.fn.rust
+            name: keyword.other.safety.rust
           2:
+            name: keyword.other.fn.rust
+          3:
             name: entity.name.function.rust
-          4:
-            name: punctuation.brackets.round.rust
           5:
+            name: punctuation.brackets.round.rust
+          6:
             name: punctuation.brackets.angle.rust
         end: (\{)|(;)
         endCaptures:
@@ -401,7 +406,7 @@ repository:
       -
         comment: other keywords
         name: keyword.other.rust
-        match: \b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\b
+        match: \b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|unsafe|unsized|use|virtual|where)\b
       -
         comment: fn
         name: keyword.other.fn.rust
@@ -419,9 +424,16 @@ repository:
         name: keyword.operator.logical.rust
         match: (\^|\||\|\||&&|<<|>>|!)(?!=)
       -
-        comment: logical AND, borrow references
+        comment: bitwise AND, borrow references
         name: keyword.operator.borrow.and.rust
-        match: '&(?![&=])'
+        match: '&(?![&=])(?:\s*(raw)\b)?(?:\s*(?:(const)|(mut))\b)?'
+        captures:
+          1:
+            name: storage.modifier.raw.rust
+          2:
+            name: storage.modifier.const.rust
+          3:
+            name: storage.modifier.mut.rust
       -
         comment: assignment operators
         name: keyword.operator.assignment.rust
@@ -614,6 +626,14 @@ repository:
             name: keyword.declaration.type.rust storage.type.rust
           2:
             name: entity.name.type.declaration.rust
+      -
+        comment: union declarations
+        match: \b(union)\s+(_?[A-Z][A-Za-z0-9_]*)\b
+        captures:
+          1:
+            name: keyword.declaration.union.rust storage.type.rust
+          2:
+            name: entity.name.type.union.rust
       -
         comment: types
         name: entity.name.type.rust

--- a/test/test.rs
+++ b/test/test.rs
@@ -87,3 +87,55 @@ macro_rules! metavariable_test {
 //           ^^^                            variable.other.metavariable.name.rust
 //              ^^^^^^^^^^^^^^^^^           - meta.macro.metavariable.rust
 }
+
+// static
+static FOO: i32;
+// <------          storage.type.rust
+//     ^^^          constant.other.caps.rust
+safe static FOO: i32;
+// <----            keyword.other.safety.rust
+//   ^^^^^^         storage.type.rust
+//          ^^^     constant.other.caps.rust
+unsafe static FOO: i32;
+// <------          keyword.other.safety.rust
+//     ^^^^^^       storage.type.rust
+//            ^^^   constant.other.caps.rust
+
+// unions
+union Foo {
+// <-----   keyword.declaration.union.rust
+//    ^^^   entity.name.type.union.rust
+}
+
+// borrows
+let x = &y;
+//      ^       keyword.operator.borrow.and.rust
+//       ^      variable.other.rust
+
+// borrows
+let x = &mut y;
+//      ^^^^        keyword.operator.borrow.and.rust
+//       ^^^        storage.modifier.mut.rust
+//           ^      variable.other.rust
+
+let x = &raw const y;
+//      ^^^^^^^^^^      keyword.operator.borrow.and.rust
+//       ^^^            storage.modifier.raw.rust
+//           ^^^^^      storage.modifier.const.rust
+//                 ^    variable.other.rust
+
+let x = &raw mut y;
+//      ^^^^^^^^        keyword.operator.borrow.and.rust
+//       ^^^            storage.modifier.raw.rust
+//           ^^^        storage.modifier.mut.rust
+//               ^      variable.other.rust
+
+// weak keywords used as variables
+let raw = raw;
+//  ^^^   ^^^       variable.other.rust - storage.modifier.raw.rust
+
+let safe = safe;
+//  ^^^^   ^^^^     variable.other.rust - keyword.other.safety.rust
+
+let union = union;
+//  ^^^^^   ^^^^^   variable.other.rust - keyword.declaration.union.rust

--- a/test/test_fn.rs
+++ b/test/test_fn.rs
@@ -1,0 +1,24 @@
+// SYNTAX TEST "source.rust" "Textmate grammar scope tests for functions"
+
+fn my_function() {}
+// <--                      keyword.other.fn.rust
+// ^^^^^^^^^^^              entity.name.function.rust
+//            ^^            punctuation.brackets.round.rust
+//               ^^         punctuation.brackets.curly.rust
+// <---------------         meta.function.definition.rust
+
+unsafe fn my_function() {}
+// <------                  keyword.other.safety.rust
+//     ^^                   keyword.other.fn.rust
+//        ^^^^^^^^^^^       entity.name.function.rust
+//                   ^^     punctuation.brackets.round.rust
+//                      ^^  punctuation.brackets.curly.rust
+// <----------------------  meta.function.definition.rust
+
+safe fn my_function();
+// <----                    keyword.other.safety.rust
+//   ^^                     keyword.other.fn.rust
+//      ^^^^^^^^^^^         entity.name.function.rust
+//                 ^^       punctuation.brackets.round.rust
+//                   ^      punctuation.semi.rust
+// <--------------------    meta.function.definition.rust


### PR DESCRIPTION
fixes #27 
See https://doc.rust-lang.org/reference/keywords.html

- Update grammar:
  - Add `safe` keyword, which can appear before a `fn` or `static` declaration
    - include `safe` and `unsafe` in `meta.function.definition.rust`
  - Add `raw` keyword, which can appear after `&` as in `&raw mut x`
  - Remove `union` from the regex of keywords that get marked `keyword.other.rust`, and adds a rule for union declarations
  - Allow `static` instead of `const` in const declarations
- Add tests for these scenarios

This also adds a "build" script so you can run `npm run build` once without starting a watcher and runs it from `pretest` so `npm test` builds before testing to prevent you from accidentally testing a stale grammar. That's not technically part of the fix, so that can be removed if it is not desired.


