### PR TITLE
feature - Classify `pub` as visibility modifier

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -451,11 +451,20 @@
         "functions": {
             "patterns": [
                 {
-                    "comment": "pub as a function",
+                    "comment": "visibility modifier",
+                    "match": "\\b(pub)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.modifier.visibility.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "pub visibility modifier with restrictions",
                     "match": "\\b(pub)(\\()",
                     "captures": {
                         "1": {
-                            "name": "keyword.other.rust"
+                            "name": "storage.modifier.visibility.rust"
                         },
                         "2": {
                             "name": "punctuation.brackets.round.rust"
@@ -710,7 +719,7 @@
                 {
                     "comment": "other keywords",
                     "name": "keyword.other.rust",
-                    "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
+                    "match": "\\b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|ref|typeof|union|unsafe|unsized|use|virtual|where)\\b"
                 },
                 {
                     "comment": "fn",

--- a/syntaxes/rust.tmLanguage.yml
+++ b/syntaxes/rust.tmLanguage.yml
@@ -262,11 +262,17 @@ repository:
   functions:
     patterns:
       -
-        comment: pub as a function
+        comment: visibility modifier
+        match: \b(pub)\b
+        captures:
+          1:
+            name: storage.modifier.visibility.rust
+      -
+        comment: pub visibility modifier with restrictions
         match: \b(pub)(\()
         captures:
           1:
-            name: keyword.other.rust
+            name: storage.modifier.visibility.rust
           2:
             name: punctuation.brackets.round.rust
       -
@@ -401,7 +407,7 @@ repository:
       -
         comment: other keywords
         name: keyword.other.rust
-        match: \b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual|where)\b
+        match: \b(as|async|become|box|dyn|move|final|gen|impl|in|override|priv|ref|typeof|union|unsafe|unsized|use|virtual|where)\b
       -
         comment: fn
         name: keyword.other.fn.rust

--- a/test/test.rs
+++ b/test/test.rs
@@ -86,4 +86,15 @@ macro_rules! metavariable_test {
 //          ^                               keyword.operator.macro.dollar.rust
 //           ^^^                            variable.other.metavariable.name.rust
 //              ^^^^^^^^^^^^^^^^^           - meta.macro.metavariable.rust
+
+    pub fn testPubModifier__01() {
+//  ^^^ storage.modifier.visibility.rust
+        let publish = 1;
+//          ^^^^^^^ - storage.modifier.visibility.rust
+        let some_str = "pub";
+//                      ^^^ - storage.modifier.visibility.rust
+    };
+
+    pub(crate) fn testPubModifier__02() {}
+//  ^^^ storage.modifier.visibility.rust
 }


### PR DESCRIPTION
Classify `pub` as `storage.modifier.visibility.rust`, removed from generic keywords (`keyword.other.rust`).
Changed `pub as a function` to a more descriptive name `pub visibility modifier with restrictions`.

closes #68.